### PR TITLE
Modify name of S3 bucket in README example (fix #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Set up a bucket to store Lambda .ZIP files...
 
 ```julia
 using AWSS3
-s3_create_bucket(aws, "com.me.jl_lambda")
-aws[:lambda_bucket] = "com.me.jl_lambda"
+s3_create_bucket(aws, "com.me.jl-lambda")
+aws[:lambda_bucket] = "com.me.jl-lambda"
 ```
 
 


### PR DESCRIPTION
Underscores in S3 bucket names are only allowed in US East region, see [S3 Docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html)