### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
 AWSSQS
 AWSS3
 AWSEC2
@@ -12,3 +12,5 @@ SymDict
 Nettle
 FNVHash
 Primes
+Retry
+AWSSNS # test-only?


### PR DESCRIPTION
since it's the first version where AWSConfig is defined

also add direct dependencies on Retry, AWSSNS which are imported but not
directly depended on (assumed to be present as transitive deps)